### PR TITLE
Use TypedArray.set instead of a for loop.

### DIFF
--- a/randomizer/templates/randomizer/_rom_base.html
+++ b/randomizer/templates/randomizer/_rom_base.html
@@ -79,9 +79,7 @@
             if (!bytes.length) {
                 this.u_array[seek] = bytes;
             } else {
-                for (let i = 0; i < bytes.length; i++) {
-                    this.u_array[seek + i] = bytes[i];
-                }
+                this.u_array.set(bytes, seek);
             }
         }
 


### PR DESCRIPTION
Since all the ROM writes are using bytes, this will skip the numerous for loops and let the JS engine handle the byte setting.