### PR TITLE
Remove pycrypto as Wii.py no longer requires it

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,6 @@ jsonfield==2.0.2
 Markdown==3.1.1
 nlzss==0.1.2
 Pillow==6.1.0
-pycrypto==2.6.1
 pytz==2019.2
 requests==2.22.0
 sqlparse==0.3.0


### PR DESCRIPTION
Pycrypto is old and unsupported.
https://github.com/DorkmasterFlek/Wii.py/pull/1
Removed the requirement from the Wii.py lib